### PR TITLE
chore(docker): Compose para PostgreSQL local

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: chiclete
+      POSTGRES_USER: chiclete
+      POSTGRES_PASSWORD: chiclete
+    ports:
+      - "5432:5432"
+    volumes:
+      - chiclete_pg_data:/var/lib/postgresql/data
+
+volumes:
+  chiclete_pg_data:


### PR DESCRIPTION
Adiciona `docker-compose.yml` para subir o banco localmente.

**Base:** `docs/project-documentation`.

Made with [Cursor](https://cursor.com)