### PR TITLE
feat(backend): perfil, notificações e modo chiclete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,11 @@ services:
     volumes:
       - chiclete_pg_data:/var/lib/postgresql/data
 
+  mailhog:
+    image: mailhog/mailhog:latest
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+
 volumes:
   chiclete_pg_data:

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.chiclete</groupId>
-	<artifactId>reminder</artifactId>
+	<artifactId>chiclete</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name/>
 	<description/>
@@ -49,6 +49,10 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.flywaydb</groupId>

--- a/src/main/java/com/chiclete/reminder/ReminderApplication.java
+++ b/src/main/java/com/chiclete/reminder/ReminderApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 @ComponentScan(
         excludeFilters = @ComponentScan.Filter(
                 type = FilterType.REGEX,

--- a/src/main/java/com/chiclete/reminder/config/SecurityConfig.java
+++ b/src/main/java/com/chiclete/reminder/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                                 "/index.html",
                                 "/css/**",
                                 "/js/**",
+                                "/img/**",
                                 "/favicon.ico"
                         ).permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/chiclete/reminder/domain/Notification.java
+++ b/src/main/java/com/chiclete/reminder/domain/Notification.java
@@ -1,0 +1,55 @@
+package com.chiclete.reminder.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reminder_id", nullable = false)
+    private Reminder reminder;
+
+    @Column(nullable = false, length = 500)
+    private String message;
+
+    @Column(nullable = false)
+    private String priorityAtSend;
+
+    @Column(nullable = false)
+    private boolean read;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    public Notification() {}
+
+    public Long getId() { return id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public Reminder getReminder() { return reminder; }
+    public void setReminder(Reminder reminder) { this.reminder = reminder; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public String getPriorityAtSend() { return priorityAtSend; }
+    public void setPriorityAtSend(String priorityAtSend) { this.priorityAtSend = priorityAtSend; }
+
+    public boolean isRead() { return read; }
+    public void setRead(boolean read) { this.read = read; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/src/main/java/com/chiclete/reminder/domain/RecurrenceSupport.java
+++ b/src/main/java/com/chiclete/reminder/domain/RecurrenceSupport.java
@@ -1,0 +1,133 @@
+package com.chiclete.reminder.domain;
+
+import com.chiclete.reminder.service.DomainRuleException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class RecurrenceSupport {
+
+    public static final String NONE = "NONE";
+    public static final String WEEKDAYS = "WEEKDAYS";
+    public static final String CUSTOM = "CUSTOM";
+    public static final String WEEKDAY_PATTERN = "1,2,3,4,5";
+
+    private RecurrenceSupport() {}
+
+    public static String normalizeType(String type) {
+        if (type == null || type.isBlank()) {
+            return NONE;
+        }
+        return type.trim().toUpperCase();
+    }
+
+    public static boolean isRecurring(Reminder reminder) {
+        return isRecurringType(reminder.getRecurrenceType()) && reminder.isRecurringEnabled();
+    }
+
+    public static boolean isRecurringType(String type) {
+        String normalized = normalizeType(type);
+        return WEEKDAYS.equals(normalized) || CUSTOM.equals(normalized);
+    }
+
+    public static String normalizeDaysForType(String type, String recurrenceDays) {
+        String normalized = normalizeType(type);
+        if (NONE.equals(normalized)) {
+            return null;
+        }
+        if (WEEKDAYS.equals(normalized)) {
+            return WEEKDAY_PATTERN;
+        }
+        Set<Integer> days = parseDaySet(recurrenceDays);
+        if (days.isEmpty()) {
+            throw new DomainRuleException("Selecione pelo menos um dia para a repetição personalizada");
+        }
+        return days.stream()
+                .sorted()
+                .map(String::valueOf)
+                .collect(Collectors.joining(","));
+    }
+
+    public static Set<Integer> resolveDays(Reminder reminder) {
+        return resolveDays(reminder.getRecurrenceType(), reminder.getRecurrenceDays());
+    }
+
+    public static Set<Integer> resolveDays(String type, String recurrenceDays) {
+        String normalized = normalizeType(type);
+        if (WEEKDAYS.equals(normalized)) {
+            return parseDaySet(WEEKDAY_PATTERN);
+        }
+        if (CUSTOM.equals(normalized)) {
+            return parseDaySet(recurrenceDays);
+        }
+        return Set.of();
+    }
+
+    public static LocalDateTime alignInitialSchedule(LocalDateTime preferred, String type, String recurrenceDays) {
+        String normalized = normalizeType(type);
+        if (NONE.equals(normalized)) {
+            return preferred;
+        }
+        Set<Integer> days = resolveDays(normalized, normalizeDaysForType(normalized, recurrenceDays));
+        LocalTime time = preferred.toLocalTime();
+        LocalDateTime candidate = LocalDateTime.of(preferred.toLocalDate(), time);
+        if (days.contains(preferred.getDayOfWeek().getValue()) && !candidate.isBefore(LocalDateTime.now())) {
+            return candidate;
+        }
+        return nextOccurrenceStrictlyAfter(LocalDateTime.now().minusSeconds(1), days, time);
+    }
+
+    public static LocalDateTime nextOccurrenceStrictlyAfter(LocalDateTime from, Reminder reminder) {
+        if (!isRecurringType(reminder.getRecurrenceType())) {
+            return reminder.getScheduledAt();
+        }
+        return nextOccurrenceStrictlyAfter(from, resolveDays(reminder), reminder.getScheduledAt().toLocalTime());
+    }
+
+    public static LocalDateTime nextOccurrenceStrictlyAfter(LocalDateTime from, Set<Integer> days, LocalTime time) {
+        if (days.isEmpty()) {
+            return from;
+        }
+        LocalDate start = from.toLocalDate();
+        for (int offset = 0; offset < 370; offset++) {
+            LocalDate date = start.plusDays(offset);
+            if (!days.contains(date.getDayOfWeek().getValue())) {
+                continue;
+            }
+            LocalDateTime candidate = LocalDateTime.of(date, time);
+            if (candidate.isAfter(from)) {
+                return candidate;
+            }
+        }
+        throw new DomainRuleException("Não foi possível calcular a próxima ocorrência do lembrete");
+    }
+
+    public static void advanceStaleSchedule(Reminder reminder, LocalDateTime now) {
+        if (!isRecurring(reminder) || reminder.isCompleted()) {
+            return;
+        }
+        if (reminder.getScheduledAt() == null || !reminder.getScheduledAt().isBefore(now)) {
+            return;
+        }
+        reminder.setScheduledAt(nextOccurrenceStrictlyAfter(now.minusSeconds(1), reminder));
+        reminder.setLastNotifiedAt(null);
+        reminder.setSnoozedUntil(null);
+    }
+
+    private static Set<Integer> parseDaySet(String recurrenceDays) {
+        if (recurrenceDays == null || recurrenceDays.isBlank()) {
+            return Set.of();
+        }
+        return Arrays.stream(recurrenceDays.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(Integer::parseInt)
+                .filter(day -> day >= 1 && day <= 7)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+}

--- a/src/main/java/com/chiclete/reminder/domain/Reminder.java
+++ b/src/main/java/com/chiclete/reminder/domain/Reminder.java
@@ -45,6 +45,26 @@ public class Reminder {
     @Column(nullable = false)
     private String priority;
 
+    /** Momento do último alerta enviado (in-app ou externo). */
+    @Column
+    private LocalDateTime lastNotifiedAt;
+
+    /** Adiamento temporário — não dispara alertas até este momento. */
+    @Column
+    private LocalDateTime snoozedUntil;
+
+    /** NONE, WEEKDAYS ou CUSTOM — lembrete recorrente nos dias configurados. */
+    @Column(nullable = false)
+    private String recurrenceType = RecurrenceSupport.NONE;
+
+    /** Dias ISO-8601 (1=seg … 7=dom), ex.: "1,2,3,4,5". */
+    @Column
+    private String recurrenceDays;
+
+    /** Quando falso, a recorrência fica pausada sem eliminar o lembrete. */
+    @Column(nullable = false)
+    private boolean recurringEnabled = true;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "owner_id", nullable = false)
     private User owner;
@@ -85,6 +105,21 @@ public class Reminder {
 
     public String getPriority() { return priority; }
     public void setPriority(String priority) { this.priority = priority; }
+
+    public LocalDateTime getLastNotifiedAt() { return lastNotifiedAt; }
+    public void setLastNotifiedAt(LocalDateTime lastNotifiedAt) { this.lastNotifiedAt = lastNotifiedAt; }
+
+    public LocalDateTime getSnoozedUntil() { return snoozedUntil; }
+    public void setSnoozedUntil(LocalDateTime snoozedUntil) { this.snoozedUntil = snoozedUntil; }
+
+    public String getRecurrenceType() { return recurrenceType; }
+    public void setRecurrenceType(String recurrenceType) { this.recurrenceType = recurrenceType; }
+
+    public String getRecurrenceDays() { return recurrenceDays; }
+    public void setRecurrenceDays(String recurrenceDays) { this.recurrenceDays = recurrenceDays; }
+
+    public boolean isRecurringEnabled() { return recurringEnabled; }
+    public void setRecurringEnabled(boolean recurringEnabled) { this.recurringEnabled = recurringEnabled; }
 
     public User getOwner() { return owner; }
     public void setOwner(User owner) { this.owner = owner; }

--- a/src/main/java/com/chiclete/reminder/domain/User.java
+++ b/src/main/java/com/chiclete/reminder/domain/User.java
@@ -26,6 +26,19 @@ public class User {
     @Column(nullable = false)
     private String role;
 
+    /** Número WhatsApp com DDI, só dígitos (ex.: 5511999998888). */
+    @Column(length = 20)
+    private String whatsapp;
+
+    @Column(nullable = false)
+    private boolean notifyEmail = true;
+
+    @Column(nullable = false)
+    private boolean notifyWhatsapp = false;
+
+    @Column(nullable = false)
+    private boolean notifyInApp = true;
+
     public User() {}
 
     public Long getId() { return id; }
@@ -41,4 +54,16 @@ public class User {
 
     public String getRole() { return role; }
     public void setRole(String role) { this.role = role; }
+
+    public String getWhatsapp() { return whatsapp; }
+    public void setWhatsapp(String whatsapp) { this.whatsapp = whatsapp; }
+
+    public boolean isNotifyEmail() { return notifyEmail; }
+    public void setNotifyEmail(boolean notifyEmail) { this.notifyEmail = notifyEmail; }
+
+    public boolean isNotifyWhatsapp() { return notifyWhatsapp; }
+    public void setNotifyWhatsapp(boolean notifyWhatsapp) { this.notifyWhatsapp = notifyWhatsapp; }
+
+    public boolean isNotifyInApp() { return notifyInApp; }
+    public void setNotifyInApp(boolean notifyInApp) { this.notifyInApp = notifyInApp; }
 }

--- a/src/main/java/com/chiclete/reminder/domain/WhatsappSimulation.java
+++ b/src/main/java/com/chiclete/reminder/domain/WhatsappSimulation.java
@@ -1,0 +1,49 @@
+package com.chiclete.reminder.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "whatsapp_simulations")
+public class WhatsappSimulation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reminder_id", nullable = false)
+    private Reminder reminder;
+
+    @Column(nullable = false, length = 20)
+    private String phone;
+
+    @Column(nullable = false, length = 500)
+    private String message;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    public WhatsappSimulation() {}
+
+    public Long getId() { return id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public Reminder getReminder() { return reminder; }
+    public void setReminder(Reminder reminder) { this.reminder = reminder; }
+
+    public String getPhone() { return phone; }
+    public void setPhone(String phone) { this.phone = phone; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+}

--- a/src/main/java/com/chiclete/reminder/dto/ChicleteStatsResponse.java
+++ b/src/main/java/com/chiclete/reminder/dto/ChicleteStatsResponse.java
@@ -1,0 +1,8 @@
+package com.chiclete.reminder.dto;
+
+public record ChicleteStatsResponse(
+        long chewingActive,
+        long chewingCompleted,
+        long totalIgnores,
+        long totalAlerts
+) {}

--- a/src/main/java/com/chiclete/reminder/dto/ForgotPasswordRequest.java
+++ b/src/main/java/com/chiclete/reminder/dto/ForgotPasswordRequest.java
@@ -1,0 +1,10 @@
+package com.chiclete.reminder.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ForgotPasswordRequest(
+        @NotBlank @Email String email,
+        @NotBlank @Size(min = 6, max = 72) String newPassword
+) {}

--- a/src/main/java/com/chiclete/reminder/dto/MessageResponse.java
+++ b/src/main/java/com/chiclete/reminder/dto/MessageResponse.java
@@ -1,0 +1,3 @@
+package com.chiclete.reminder.dto;
+
+public record MessageResponse(String message) {}

--- a/src/main/java/com/chiclete/reminder/dto/NotificationResponse.java
+++ b/src/main/java/com/chiclete/reminder/dto/NotificationResponse.java
@@ -1,0 +1,15 @@
+package com.chiclete.reminder.dto;
+
+import java.time.LocalDateTime;
+
+public record NotificationResponse(
+        Long id,
+        Long reminderId,
+        String reminderTitle,
+        String message,
+        String priorityAtSend,
+        boolean chewing,
+        boolean read,
+        LocalDateTime createdAt,
+        String whatsappLink
+) {}

--- a/src/main/java/com/chiclete/reminder/dto/PatchRecurrenceRequest.java
+++ b/src/main/java/com/chiclete/reminder/dto/PatchRecurrenceRequest.java
@@ -1,0 +1,5 @@
+package com.chiclete.reminder.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PatchRecurrenceRequest(@NotNull Boolean enabled) {}

--- a/src/main/java/com/chiclete/reminder/dto/ProfileResponse.java
+++ b/src/main/java/com/chiclete/reminder/dto/ProfileResponse.java
@@ -1,0 +1,11 @@
+package com.chiclete.reminder.dto;
+
+public record ProfileResponse(
+        Long id,
+        String name,
+        String email,
+        String whatsapp,
+        boolean notifyEmail,
+        boolean notifyWhatsapp,
+        boolean notifyInApp
+) {}

--- a/src/main/java/com/chiclete/reminder/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/chiclete/reminder/dto/ProfileUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.chiclete.reminder.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record ProfileUpdateRequest(
+        @Size(max = 120) String name,
+        @Size(max = 20) String whatsapp,
+        Boolean notifyEmail,
+        Boolean notifyWhatsapp,
+        Boolean notifyInApp
+) {}

--- a/src/main/java/com/chiclete/reminder/dto/ReminderRequest.java
+++ b/src/main/java/com/chiclete/reminder/dto/ReminderRequest.java
@@ -12,5 +12,8 @@ public record ReminderRequest(
         @NotNull LocalDateTime scheduledAt,
         boolean chewing,
         Integer intervalMinutes,
-        @NotBlank @Size(max = 50) String priority
+        @NotBlank @Size(max = 50) String priority,
+        String recurrenceType,
+        String recurrenceDays,
+        Boolean recurringEnabled
 ) {}

--- a/src/main/java/com/chiclete/reminder/dto/ReminderResponse.java
+++ b/src/main/java/com/chiclete/reminder/dto/ReminderResponse.java
@@ -13,6 +13,9 @@ public record ReminderResponse(
         int ignoreCount,
         boolean completed,
         String priority,
+        String recurrenceType,
+        String recurrenceDays,
+        boolean recurringEnabled,
         Long ownerId,
         List<String> sharedWithEmails
 ) {}

--- a/src/main/java/com/chiclete/reminder/dto/WhatsappSimulationResponse.java
+++ b/src/main/java/com/chiclete/reminder/dto/WhatsappSimulationResponse.java
@@ -1,0 +1,12 @@
+package com.chiclete.reminder.dto;
+
+import java.time.LocalDateTime;
+
+public record WhatsappSimulationResponse(
+        Long id,
+        Long reminderId,
+        String reminderTitle,
+        String phone,
+        String message,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/chiclete/reminder/infra/NotificationRepository.java
+++ b/src/main/java/com/chiclete/reminder/infra/NotificationRepository.java
@@ -1,0 +1,21 @@
+package com.chiclete.reminder.infra;
+
+import com.chiclete.reminder.domain.Notification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByUserIdAndReadFalseOrderByCreatedAtDesc(Long userId);
+
+    List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    long countByUserIdAndReadFalse(Long userId);
+
+    long countByUserId(Long userId);
+
+    Optional<Notification> findByIdAndUserId(Long id, Long userId);
+}

--- a/src/main/java/com/chiclete/reminder/infra/ReminderRepository.java
+++ b/src/main/java/com/chiclete/reminder/infra/ReminderRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ReminderRepository extends JpaRepository<Reminder, Long> {
+
+    List<Reminder> findByCompletedFalseAndScheduledAtLessThanEqual(LocalDateTime now);
 
     @Query("""
             SELECT DISTINCT r FROM Reminder r

--- a/src/main/java/com/chiclete/reminder/infra/WhatsappSimulationRepository.java
+++ b/src/main/java/com/chiclete/reminder/infra/WhatsappSimulationRepository.java
@@ -1,0 +1,14 @@
+package com.chiclete.reminder.infra;
+
+import com.chiclete.reminder.domain.WhatsappSimulation;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface WhatsappSimulationRepository extends JpaRepository<WhatsappSimulation, Long> {
+
+    List<WhatsappSimulation> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    long countByUserId(Long userId);
+}

--- a/src/main/java/com/chiclete/reminder/service/AuthService.java
+++ b/src/main/java/com/chiclete/reminder/service/AuthService.java
@@ -52,4 +52,11 @@ public class AuthService {
                 .orElseThrow(() -> new DomainRuleException("Credenciais inválidas"));
         return new TokenResponse(jwtService.generateToken(user));
     }
+
+    @Transactional
+    public void resetPassword(String email, String newPassword) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new DomainRuleException("E-mail não encontrado"));
+        user.setPassword(passwordEncoder.encode(newPassword));
+    }
 }

--- a/src/main/java/com/chiclete/reminder/service/ChicleteScheduler.java
+++ b/src/main/java/com/chiclete/reminder/service/ChicleteScheduler.java
@@ -1,0 +1,74 @@
+package com.chiclete.reminder.service;
+
+import com.chiclete.reminder.domain.RecurrenceSupport;
+import com.chiclete.reminder.domain.Reminder;
+import com.chiclete.reminder.infra.ReminderRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+public class ChicleteScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(ChicleteScheduler.class);
+
+    private final ReminderRepository reminderRepository;
+    private final NotificationService notificationService;
+
+    public ChicleteScheduler(ReminderRepository reminderRepository, NotificationService notificationService) {
+        this.reminderRepository = reminderRepository;
+        this.notificationService = notificationService;
+    }
+
+    @Scheduled(fixedRateString = "${app.notifications.poll-interval-ms:60000}")
+    @Transactional
+    public void dispatchDueAlerts() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Reminder> candidates = reminderRepository.findByCompletedFalseAndScheduledAtLessThanEqual(now);
+
+        int sent = 0;
+        for (Reminder reminder : candidates) {
+            RecurrenceSupport.advanceStaleSchedule(reminder, now);
+            if (isDueForNotification(reminder, now)) {
+                notificationService.createAlertsForReminder(reminder, now);
+                if (RecurrenceSupport.isRecurring(reminder) && !reminder.isChewing()) {
+                    reminder.setScheduledAt(RecurrenceSupport.nextOccurrenceStrictlyAfter(now, reminder));
+                    reminder.setLastNotifiedAt(null);
+                }
+                sent++;
+            }
+        }
+        if (sent > 0) {
+            log.info("Modo Chiclete: {} lembrete(s) com alerta disparado", sent);
+        }
+    }
+
+    public static boolean isDueForNotification(Reminder reminder, LocalDateTime now) {
+        if (reminder.isCompleted() || reminder.getScheduledAt().isAfter(now)) {
+            return false;
+        }
+        if (RecurrenceSupport.isRecurringType(reminder.getRecurrenceType()) && !reminder.isRecurringEnabled()) {
+            return false;
+        }
+        if (reminder.getSnoozedUntil() != null && reminder.getSnoozedUntil().isAfter(now)) {
+            return false;
+        }
+        LocalDateTime last = reminder.getLastNotifiedAt();
+        if (last == null) {
+            return true;
+        }
+        if (!reminder.isChewing()) {
+            return false;
+        }
+        Integer interval = reminder.getIntervalMinutes();
+        if (interval == null || interval <= 0) {
+            interval = 30;
+        }
+        return !last.plusMinutes(interval).isAfter(now);
+    }
+}

--- a/src/main/java/com/chiclete/reminder/service/ChicleteStatsService.java
+++ b/src/main/java/com/chiclete/reminder/service/ChicleteStatsService.java
@@ -1,0 +1,33 @@
+package com.chiclete.reminder.service;
+
+import com.chiclete.reminder.domain.Reminder;
+import com.chiclete.reminder.domain.User;
+import com.chiclete.reminder.dto.ChicleteStatsResponse;
+import com.chiclete.reminder.infra.NotificationRepository;
+import com.chiclete.reminder.infra.ReminderRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class ChicleteStatsService {
+
+    private final ReminderRepository reminderRepository;
+    private final NotificationRepository notificationRepository;
+
+    public ChicleteStatsService(ReminderRepository reminderRepository, NotificationRepository notificationRepository) {
+        this.reminderRepository = reminderRepository;
+        this.notificationRepository = notificationRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public ChicleteStatsResponse getStats(User user) {
+        List<Reminder> visible = reminderRepository.findAllVisibleToUser(user.getId());
+        long active = visible.stream().filter(r -> r.isChewing() && !r.isCompleted()).count();
+        long completed = visible.stream().filter(r -> r.isChewing() && r.isCompleted()).count();
+        long totalIgnores = visible.stream().mapToLong(Reminder::getIgnoreCount).sum();
+        long totalAlerts = notificationRepository.countByUserId(user.getId());
+        return new ChicleteStatsResponse(active, completed, totalIgnores, totalAlerts);
+    }
+}

--- a/src/main/java/com/chiclete/reminder/service/EmailNotificationService.java
+++ b/src/main/java/com/chiclete/reminder/service/EmailNotificationService.java
@@ -1,0 +1,59 @@
+package com.chiclete.reminder.service;
+
+import com.chiclete.reminder.domain.Reminder;
+import com.chiclete.reminder.domain.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailNotificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(EmailNotificationService.class);
+
+    private final JavaMailSender mailSender;
+    private final boolean enabled;
+    private final String fromAddress;
+
+    public EmailNotificationService(
+            JavaMailSender mailSender,
+            @Value("${app.mail.enabled:true}") boolean enabled,
+            @Value("${app.mail.from:chiclete@localhost}") String fromAddress
+    ) {
+        this.mailSender = mailSender;
+        this.enabled = enabled;
+        this.fromAddress = fromAddress;
+    }
+
+    public void sendReminderAlert(User user, Reminder reminder, String message) {
+        if (!enabled || !user.isNotifyEmail() || user.getEmail() == null || user.getEmail().isBlank()) {
+            return;
+        }
+        try {
+            SimpleMailMessage mail = new SimpleMailMessage();
+            mail.setFrom(fromAddress);
+            mail.setTo(user.getEmail());
+            mail.setSubject("🫧 Chiclete — " + reminder.getTitle());
+            mail.setText(buildBody(user, reminder, message));
+            mailSender.send(mail);
+            log.info("E-mail Chiclete enviado para {}", user.getEmail());
+        } catch (Exception e) {
+            log.warn("Falha ao enviar e-mail Chiclete para {}: {}", user.getEmail(), e.getMessage());
+        }
+    }
+
+    private String buildBody(User user, Reminder reminder, String message) {
+        StringBuilder body = new StringBuilder();
+        body.append("Olá ").append(user.getName()).append("!\n\n");
+        body.append("Lembrete Chiclete: ").append(message).append("\n");
+        body.append("Prioridade: ").append(reminder.getPriority()).append("\n");
+        if (reminder.getDescription() != null && !reminder.getDescription().isBlank()) {
+            body.append("\n").append(reminder.getDescription()).append("\n");
+        }
+        body.append("\n— Chiclete Reminder");
+        return body.toString();
+    }
+}

--- a/src/main/java/com/chiclete/reminder/service/NotificationService.java
+++ b/src/main/java/com/chiclete/reminder/service/NotificationService.java
@@ -1,0 +1,152 @@
+package com.chiclete.reminder.service;
+
+import com.chiclete.reminder.domain.Notification;
+import com.chiclete.reminder.domain.Reminder;
+import com.chiclete.reminder.domain.User;
+import com.chiclete.reminder.dto.NotificationResponse;
+import com.chiclete.reminder.infra.NotificationRepository;
+import com.chiclete.reminder.infra.ReminderRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+public class NotificationService {
+
+    private static final int DEFAULT_SNOOZE_MINUTES = 10;
+    private static final int HISTORY_LIMIT = 50;
+
+    private final NotificationRepository notificationRepository;
+    private final ReminderRepository reminderRepository;
+    private final ReminderService reminderService;
+    private final EmailNotificationService emailNotificationService;
+    private final WhatsappSimulationService whatsappSimulationService;
+
+    public NotificationService(
+            NotificationRepository notificationRepository,
+            ReminderRepository reminderRepository,
+            ReminderService reminderService,
+            EmailNotificationService emailNotificationService,
+            WhatsappSimulationService whatsappSimulationService
+    ) {
+        this.notificationRepository = notificationRepository;
+        this.reminderRepository = reminderRepository;
+        this.reminderService = reminderService;
+        this.emailNotificationService = emailNotificationService;
+        this.whatsappSimulationService = whatsappSimulationService;
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> listUnread(User user) {
+        return notificationRepository.findByUserIdAndReadFalseOrderByCreatedAtDesc(user.getId()).stream()
+                .map(n -> toResponse(n, user))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> listHistory(User user) {
+        return notificationRepository
+                .findByUserIdOrderByCreatedAtDesc(user.getId(), PageRequest.of(0, HISTORY_LIMIT))
+                .stream()
+                .map(n -> toResponse(n, user))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public long countUnread(User user) {
+        return notificationRepository.countByUserIdAndReadFalse(user.getId());
+    }
+
+    @Transactional
+    public NotificationResponse markRead(Long id, User user) {
+        Notification n = getOwnedNotification(id, user);
+        n.setRead(true);
+        notificationRepository.save(n);
+        return toResponse(n, user);
+    }
+
+    @Transactional
+    public NotificationResponse dismiss(Long id, User user) {
+        Notification n = getOwnedNotification(id, user);
+        n.setRead(true);
+        notificationRepository.save(n);
+        if (n.getReminder().isChewing() && !n.getReminder().isCompleted()) {
+            reminderService.recordChewingIgnored(n.getReminder().getId(), user);
+        }
+        return toResponse(n, user);
+    }
+
+    @Transactional
+    public NotificationResponse snooze(Long id, User user) {
+        Notification n = getOwnedNotification(id, user);
+        n.setRead(true);
+        notificationRepository.save(n);
+        reminderService.snooze(n.getReminder().getId(), DEFAULT_SNOOZE_MINUTES, user);
+        return toResponse(n, user);
+    }
+
+    @Transactional
+    public void createAlertsForReminder(Reminder reminder, LocalDateTime now) {
+        String message = buildMessage(reminder);
+        Set<User> recipients = collectRecipients(reminder);
+
+        for (User recipient : recipients) {
+            if (recipient.isNotifyInApp()) {
+                Notification notification = new Notification();
+                notification.setUser(recipient);
+                notification.setReminder(reminder);
+                notification.setMessage(message);
+                notification.setPriorityAtSend(reminder.getPriority());
+                notification.setRead(false);
+                notification.setCreatedAt(now);
+                notificationRepository.save(notification);
+            }
+            emailNotificationService.sendReminderAlert(recipient, reminder, message);
+            whatsappSimulationService.simulateSend(recipient, reminder, message, now);
+        }
+
+        reminder.setLastNotifiedAt(now);
+        reminderRepository.save(reminder);
+    }
+
+    private Notification getOwnedNotification(Long id, User user) {
+        return notificationRepository.findByIdAndUserId(id, user.getId())
+                .orElseThrow(() -> new NotFoundException("Notificação não encontrada"));
+    }
+
+    private Set<User> collectRecipients(Reminder reminder) {
+        Set<User> recipients = new LinkedHashSet<>();
+        recipients.add(reminder.getOwner());
+        recipients.addAll(reminder.getSharedWith());
+        return recipients;
+    }
+
+    private String buildMessage(Reminder reminder) {
+        String chewingTag = reminder.isChewing() ? " 🫧 Chiclete" : "";
+        String ignoreTag = reminder.getIgnoreCount() > 0 ? " (ignorado " + reminder.getIgnoreCount() + "×)" : "";
+        return reminder.getTitle() + chewingTag + ignoreTag;
+    }
+
+    private NotificationResponse toResponse(Notification n, User viewer) {
+        String link = null;
+        if (viewer.isNotifyWhatsapp() && viewer.getWhatsapp() != null) {
+            link = ProfileService.buildWhatsappLink(viewer.getWhatsapp(), n.getMessage());
+        }
+        return new NotificationResponse(
+                n.getId(),
+                n.getReminder().getId(),
+                n.getReminder().getTitle(),
+                n.getMessage(),
+                n.getPriorityAtSend(),
+                n.getReminder().isChewing(),
+                n.isRead(),
+                n.getCreatedAt(),
+                link
+        );
+    }
+}

--- a/src/main/java/com/chiclete/reminder/service/ProfileService.java
+++ b/src/main/java/com/chiclete/reminder/service/ProfileService.java
@@ -1,0 +1,71 @@
+package com.chiclete.reminder.service;
+
+import com.chiclete.reminder.domain.User;
+import com.chiclete.reminder.dto.ProfileResponse;
+import com.chiclete.reminder.dto.ProfileUpdateRequest;
+import com.chiclete.reminder.infra.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ProfileService {
+
+    private final UserRepository userRepository;
+
+    public ProfileService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileResponse get(User user) {
+        return toResponse(user);
+    }
+
+    @Transactional
+    public ProfileResponse update(User user, ProfileUpdateRequest request) {
+        if (request.name() != null && !request.name().isBlank()) {
+            user.setName(request.name().trim());
+        }
+        if (request.whatsapp() != null) {
+            user.setWhatsapp(normalizeWhatsapp(request.whatsapp()));
+        }
+        if (request.notifyEmail() != null) {
+            user.setNotifyEmail(request.notifyEmail());
+        }
+        if (request.notifyWhatsapp() != null) {
+            user.setNotifyWhatsapp(request.notifyWhatsapp());
+        }
+        if (request.notifyInApp() != null) {
+            user.setNotifyInApp(request.notifyInApp());
+        }
+        userRepository.save(user);
+        return toResponse(user);
+    }
+
+    static String normalizeWhatsapp(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        String digits = raw.replaceAll("\\D", "");
+        return digits.isEmpty() ? null : digits;
+    }
+
+    static String buildWhatsappLink(String whatsapp, String message) {
+        if (whatsapp == null || whatsapp.isBlank() || message == null || message.isBlank()) {
+            return null;
+        }
+        return "https://wa.me/" + whatsapp + "?text=" + java.net.URLEncoder.encode(message, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    private ProfileResponse toResponse(User user) {
+        return new ProfileResponse(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getWhatsapp(),
+                user.isNotifyEmail(),
+                user.isNotifyWhatsapp(),
+                user.isNotifyInApp()
+        );
+    }
+}

--- a/src/main/java/com/chiclete/reminder/service/ReminderService.java
+++ b/src/main/java/com/chiclete/reminder/service/ReminderService.java
@@ -1,5 +1,6 @@
 package com.chiclete.reminder.service;
 
+import com.chiclete.reminder.domain.RecurrenceSupport;
 import com.chiclete.reminder.domain.Reminder;
 import com.chiclete.reminder.domain.User;
 import com.chiclete.reminder.dto.ReminderRequest;
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -78,9 +80,39 @@ public class ReminderService {
     @Transactional
     public ReminderResponse setCompleted(Long id, boolean completed, User user) {
         Reminder r = getVisibleReminderOrThrow(id, user);
+        if (completed && RecurrenceSupport.isRecurring(r)) {
+            r.setCompleted(false);
+            r.setIgnoreCount(0);
+            r.setLastNotifiedAt(null);
+            r.setSnoozedUntil(null);
+            r.setScheduledAt(RecurrenceSupport.nextOccurrenceStrictlyAfter(java.time.LocalDateTime.now(), r));
+            reminderRepository.save(r);
+            return toResponse(r);
+        }
         r.setCompleted(completed);
         if (completed) {
             r.setIgnoreCount(0);
+            r.setLastNotifiedAt(null);
+            r.setSnoozedUntil(null);
+        }
+        reminderRepository.save(r);
+        return toResponse(r);
+    }
+
+    @Transactional
+    public ReminderResponse setRecurringEnabled(Long id, boolean enabled, User user) {
+        Reminder r = getOwnedReminderOrThrow(id, user);
+        if (!RecurrenceSupport.isRecurringType(r.getRecurrenceType())) {
+            throw new DomainRuleException("Este lembrete não possui repetição configurada");
+        }
+        r.setRecurringEnabled(enabled);
+        if (enabled) {
+            r.setCompleted(false);
+            r.setScheduledAt(RecurrenceSupport.alignInitialSchedule(
+                    r.getScheduledAt(),
+                    r.getRecurrenceType(),
+                    r.getRecurrenceDays()
+            ));
         }
         reminderRepository.save(r);
         return toResponse(r);
@@ -90,6 +122,20 @@ public class ReminderService {
     public ReminderResponse setChewing(Long id, boolean chewing, User user) {
         Reminder r = getVisibleReminderOrThrow(id, user);
         r.setChewing(chewing);
+        reminderRepository.save(r);
+        return toResponse(r);
+    }
+
+    @Transactional
+    public ReminderResponse snooze(Long id, int minutes, User user) {
+        Reminder r = getVisibleReminderOrThrow(id, user);
+        if (r.isCompleted()) {
+            throw new DomainRuleException("Lembrete já concluído");
+        }
+        if (minutes <= 0) {
+            throw new DomainRuleException("Minutos de adiamento inválidos");
+        }
+        r.setSnoozedUntil(java.time.LocalDateTime.now().plusMinutes(minutes));
         reminderRepository.save(r);
         return toResponse(r);
     }
@@ -123,12 +169,25 @@ public class ReminderService {
     }
 
     private void applyRequest(Reminder r, ReminderRequest request) {
+        String recurrenceType = RecurrenceSupport.normalizeType(request.recurrenceType());
+        String recurrenceDays = RecurrenceSupport.normalizeDaysForType(recurrenceType, request.recurrenceDays());
+        boolean recurringEnabled = request.recurringEnabled() == null || request.recurringEnabled();
+
         r.setTitle(request.title());
         r.setDescription(request.description());
-        r.setScheduledAt(request.scheduledAt());
         r.setChewing(request.chewing());
         r.setIntervalMinutes(request.intervalMinutes());
         r.setPriority(normalizePriority(request.priority()));
+        r.setRecurrenceType(recurrenceType);
+        r.setRecurrenceDays(recurrenceDays);
+        r.setRecurringEnabled(recurringEnabled);
+
+        LocalDateTime scheduledAt = RecurrenceSupport.alignInitialSchedule(
+                request.scheduledAt(),
+                recurrenceType,
+                recurrenceDays
+        );
+        r.setScheduledAt(scheduledAt);
     }
 
     private String normalizePriority(String p) {
@@ -199,6 +258,9 @@ public class ReminderService {
                 r.getIgnoreCount(),
                 r.isCompleted(),
                 r.getPriority(),
+                r.getRecurrenceType(),
+                r.getRecurrenceDays(),
+                r.isRecurringEnabled(),
                 r.getOwner().getId(),
                 sharedEmails
         );

--- a/src/main/java/com/chiclete/reminder/service/WhatsappSimulationService.java
+++ b/src/main/java/com/chiclete/reminder/service/WhatsappSimulationService.java
@@ -1,0 +1,77 @@
+package com.chiclete.reminder.service;
+
+import com.chiclete.reminder.domain.Reminder;
+import com.chiclete.reminder.domain.User;
+import com.chiclete.reminder.domain.WhatsappSimulation;
+import com.chiclete.reminder.dto.WhatsappSimulationResponse;
+import com.chiclete.reminder.infra.WhatsappSimulationRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class WhatsappSimulationService {
+
+    private static final Logger log = LoggerFactory.getLogger(WhatsappSimulationService.class);
+    private static final int HISTORY_LIMIT = 50;
+
+    private final WhatsappSimulationRepository repository;
+    private final boolean enabled;
+
+    public WhatsappSimulationService(
+            WhatsappSimulationRepository repository,
+            @Value("${app.whatsapp.simulation.enabled:true}") boolean enabled
+    ) {
+        this.repository = repository;
+        this.enabled = enabled;
+    }
+
+    @Transactional
+    public void simulateSend(User user, Reminder reminder, String message, LocalDateTime now) {
+        if (!enabled || !user.isNotifyWhatsapp()) {
+            return;
+        }
+        String phone = ProfileService.normalizeWhatsapp(user.getWhatsapp());
+        if (phone == null) {
+            return;
+        }
+        WhatsappSimulation sim = new WhatsappSimulation();
+        sim.setUser(user);
+        sim.setReminder(reminder);
+        sim.setPhone(phone);
+        sim.setMessage(message);
+        sim.setCreatedAt(now);
+        repository.save(sim);
+        log.info("[WhatsApp SIM] → {} | {}", phone, message);
+    }
+
+    @Transactional(readOnly = true)
+    public List<WhatsappSimulationResponse> listRecent(User user) {
+        return repository.findByUserIdOrderByCreatedAtDesc(user.getId(), PageRequest.of(0, HISTORY_LIMIT))
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public long count(User user) {
+        return repository.countByUserId(user.getId());
+    }
+
+    private WhatsappSimulationResponse toResponse(WhatsappSimulation s) {
+        return new WhatsappSimulationResponse(
+                s.getId(),
+                s.getReminder().getId(),
+                s.getReminder().getTitle(),
+                s.getPhone(),
+                s.getMessage(),
+                s.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/chiclete/reminder/ui/AuthController.java
+++ b/src/main/java/com/chiclete/reminder/ui/AuthController.java
@@ -1,6 +1,8 @@
 package com.chiclete.reminder.ui;
 
+import com.chiclete.reminder.dto.ForgotPasswordRequest;
 import com.chiclete.reminder.dto.LoginRequest;
+import com.chiclete.reminder.dto.MessageResponse;
 import com.chiclete.reminder.dto.RegisterRequest;
 import com.chiclete.reminder.dto.TokenResponse;
 import com.chiclete.reminder.service.AuthService;
@@ -27,5 +29,11 @@ public class AuthController {
     @PostMapping("/login")
     public TokenResponse login(@Valid @RequestBody LoginRequest request) {
         return authService.login(request.email(), request.password());
+    }
+
+    @PostMapping("/forgot-password")
+    public MessageResponse forgotPassword(@Valid @RequestBody ForgotPasswordRequest request) {
+        authService.resetPassword(request.email(), request.newPassword());
+        return new MessageResponse("Senha redefinida. Já podes entrar.");
     }
 }

--- a/src/main/java/com/chiclete/reminder/ui/NotificationController.java
+++ b/src/main/java/com/chiclete/reminder/ui/NotificationController.java
@@ -1,0 +1,53 @@
+package com.chiclete.reminder.ui;
+
+import com.chiclete.reminder.dto.NotificationResponse;
+import com.chiclete.reminder.service.CurrentUserService;
+import com.chiclete.reminder.service.NotificationService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final CurrentUserService currentUserService;
+
+    public NotificationController(NotificationService notificationService, CurrentUserService currentUserService) {
+        this.notificationService = notificationService;
+        this.currentUserService = currentUserService;
+    }
+
+    @GetMapping
+    public List<NotificationResponse> listUnread() {
+        return notificationService.listUnread(currentUserService.requireCurrentUser());
+    }
+
+    @GetMapping("/count")
+    public Map<String, Long> countUnread() {
+        long count = notificationService.countUnread(currentUserService.requireCurrentUser());
+        return Map.of("unread", count);
+    }
+
+    @PatchMapping("/{id}/read")
+    public NotificationResponse markRead(@PathVariable Long id) {
+        return notificationService.markRead(id, currentUserService.requireCurrentUser());
+    }
+
+    @PostMapping("/{id}/dismiss")
+    public NotificationResponse dismiss(@PathVariable Long id) {
+        return notificationService.dismiss(id, currentUserService.requireCurrentUser());
+    }
+
+    @PostMapping("/{id}/snooze")
+    public NotificationResponse snooze(@PathVariable Long id) {
+        return notificationService.snooze(id, currentUserService.requireCurrentUser());
+    }
+
+    @GetMapping("/history")
+    public List<NotificationResponse> history() {
+        return notificationService.listHistory(currentUserService.requireCurrentUser());
+    }
+}

--- a/src/main/java/com/chiclete/reminder/ui/ProfileController.java
+++ b/src/main/java/com/chiclete/reminder/ui/ProfileController.java
@@ -1,0 +1,31 @@
+package com.chiclete.reminder.ui;
+
+import com.chiclete.reminder.dto.ProfileResponse;
+import com.chiclete.reminder.dto.ProfileUpdateRequest;
+import com.chiclete.reminder.service.CurrentUserService;
+import com.chiclete.reminder.service.ProfileService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/profile")
+public class ProfileController {
+
+    private final ProfileService profileService;
+    private final CurrentUserService currentUserService;
+
+    public ProfileController(ProfileService profileService, CurrentUserService currentUserService) {
+        this.profileService = profileService;
+        this.currentUserService = currentUserService;
+    }
+
+    @GetMapping
+    public ProfileResponse get() {
+        return profileService.get(currentUserService.requireCurrentUser());
+    }
+
+    @PutMapping
+    public ProfileResponse update(@Valid @RequestBody ProfileUpdateRequest request) {
+        return profileService.update(currentUserService.requireCurrentUser(), request);
+    }
+}

--- a/src/main/java/com/chiclete/reminder/ui/ReminderController.java
+++ b/src/main/java/com/chiclete/reminder/ui/ReminderController.java
@@ -58,9 +58,19 @@ public class ReminderController {
         return reminderService.setChewing(id, body.chewing(), currentUserService.requireCurrentUser());
     }
 
+    @PatchMapping("/{id}/recurrence")
+    public ReminderResponse patchRecurrence(@PathVariable Long id, @Valid @RequestBody PatchRecurrenceRequest body) {
+        return reminderService.setRecurringEnabled(id, body.enabled(), currentUserService.requireCurrentUser());
+    }
+
     @PostMapping("/{id}/chewing/ignore")
     public ReminderResponse chewingIgnored(@PathVariable Long id) {
         return reminderService.recordChewingIgnored(id, currentUserService.requireCurrentUser());
+    }
+
+    @PostMapping("/{id}/snooze")
+    public ReminderResponse snooze(@PathVariable Long id) {
+        return reminderService.snooze(id, 10, currentUserService.requireCurrentUser());
     }
 
     @PostMapping("/{id}/share")

--- a/src/main/java/com/chiclete/reminder/ui/StatsController.java
+++ b/src/main/java/com/chiclete/reminder/ui/StatsController.java
@@ -1,0 +1,26 @@
+package com.chiclete.reminder.ui;
+
+import com.chiclete.reminder.dto.ChicleteStatsResponse;
+import com.chiclete.reminder.service.ChicleteStatsService;
+import com.chiclete.reminder.service.CurrentUserService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/stats")
+public class StatsController {
+
+    private final ChicleteStatsService chicleteStatsService;
+    private final CurrentUserService currentUserService;
+
+    public StatsController(ChicleteStatsService chicleteStatsService, CurrentUserService currentUserService) {
+        this.chicleteStatsService = chicleteStatsService;
+        this.currentUserService = currentUserService;
+    }
+
+    @GetMapping("/chiclete")
+    public ChicleteStatsResponse chiclete() {
+        return chicleteStatsService.getStats(currentUserService.requireCurrentUser());
+    }
+}

--- a/src/main/java/com/chiclete/reminder/ui/WhatsappSimulationController.java
+++ b/src/main/java/com/chiclete/reminder/ui/WhatsappSimulationController.java
@@ -1,0 +1,38 @@
+package com.chiclete.reminder.ui;
+
+import com.chiclete.reminder.dto.WhatsappSimulationResponse;
+import com.chiclete.reminder.service.CurrentUserService;
+import com.chiclete.reminder.service.WhatsappSimulationService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/whatsapp")
+public class WhatsappSimulationController {
+
+    private final WhatsappSimulationService whatsappSimulationService;
+    private final CurrentUserService currentUserService;
+
+    public WhatsappSimulationController(
+            WhatsappSimulationService whatsappSimulationService,
+            CurrentUserService currentUserService
+    ) {
+        this.whatsappSimulationService = whatsappSimulationService;
+        this.currentUserService = currentUserService;
+    }
+
+    @GetMapping("/simulations")
+    public List<WhatsappSimulationResponse> list() {
+        return whatsappSimulationService.listRecent(currentUserService.requireCurrentUser());
+    }
+
+    @GetMapping("/simulations/count")
+    public Map<String, Long> count() {
+        long total = whatsappSimulationService.count(currentUserService.requireCurrentUser());
+        return Map.of("total", total);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.application.name=reminder
+spring.application.name=chiclete
 
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/chiclete}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:chiclete}
@@ -11,5 +11,14 @@ spring.flyway.enabled=true
 app.jwt.secret=${APP_JWT_SECRET:0123456789012345678901234567890123456789012345678901234567890123}
 app.jwt.expiration-ms=86400000
 app.chewing.ignore-threshold=3
+app.notifications.poll-interval-ms=60000
+
+spring.mail.host=${SPRING_MAIL_HOST:localhost}
+spring.mail.port=${SPRING_MAIL_PORT:1025}
+spring.mail.properties.mail.smtp.auth=false
+spring.mail.properties.mail.smtp.starttls.enable=false
+app.mail.enabled=${APP_MAIL_ENABLED:true}
+app.mail.from=${APP_MAIL_FROM:chiclete@localhost}
+app.whatsapp.simulation.enabled=${APP_WHATSAPP_SIMULATION_ENABLED:true}
 
 management.endpoints.web.exposure.include=health,info

--- a/src/main/resources/db/migration/V3__user_profile_and_notifications.sql
+++ b/src/main/resources/db/migration/V3__user_profile_and_notifications.sql
@@ -1,0 +1,20 @@
+ALTER TABLE users
+    ADD COLUMN whatsapp VARCHAR(20),
+    ADD COLUMN notify_email BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN notify_whatsapp BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN notify_in_app BOOLEAN NOT NULL DEFAULT TRUE;
+
+ALTER TABLE reminders
+    ADD COLUMN last_notified_at TIMESTAMP;
+
+CREATE TABLE notifications (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    reminder_id BIGINT NOT NULL REFERENCES reminders (id) ON DELETE CASCADE,
+    message VARCHAR(500) NOT NULL,
+    priority_at_send VARCHAR(50) NOT NULL,
+    read BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_notifications_user_unread ON notifications (user_id, read, created_at DESC);

--- a/src/main/resources/db/migration/V4__reminder_snooze.sql
+++ b/src/main/resources/db/migration/V4__reminder_snooze.sql
@@ -1,0 +1,2 @@
+ALTER TABLE reminders
+    ADD COLUMN snoozed_until TIMESTAMP;

--- a/src/main/resources/db/migration/V5__whatsapp_simulations.sql
+++ b/src/main/resources/db/migration/V5__whatsapp_simulations.sql
@@ -1,0 +1,10 @@
+CREATE TABLE whatsapp_simulations (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    reminder_id BIGINT NOT NULL REFERENCES reminders (id) ON DELETE CASCADE,
+    phone VARCHAR(20) NOT NULL,
+    message VARCHAR(500) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_whatsapp_sim_user ON whatsapp_simulations (user_id, created_at DESC);

--- a/src/main/resources/db/migration/V6__reminder_recurrence.sql
+++ b/src/main/resources/db/migration/V6__reminder_recurrence.sql
@@ -1,0 +1,4 @@
+ALTER TABLE reminders
+    ADD COLUMN recurrence_type VARCHAR(20) NOT NULL DEFAULT 'NONE',
+    ADD COLUMN recurrence_days VARCHAR(32),
+    ADD COLUMN recurring_enabled BOOLEAN NOT NULL DEFAULT TRUE;


### PR DESCRIPTION
## Summary
- Migrations Flyway V3–V6 (perfil, notificações, snooze, WhatsApp simulado, recorrência)
- Endpoints de perfil, notificações, estatísticas e simulação WhatsApp
- Scheduler do Modo Chiclete, snooze, recorrência e recuperação de senha
- MailHog no Docker Compose para e-mails de desenvolvimento

## Test plan
- [ ] `docker compose up -d` sobe PostgreSQL e MailHog
- [ ] `./mvnw spring-boot:run` aplica migrations V3–V6
- [ ] Endpoints `/api/profile`, `/api/notifications`, `/api/stats` respondem com JWT válido


Made with [Cursor](https://cursor.com)