### PR TITLE
chore: atualiza .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,15 +39,15 @@ build/
 .jdk/
 
 ### Web client (Vite/npm) — artefatos locais ###
-chiclete-reminder-web/node_modules/
-chiclete-reminder-web/dist/
-chiclete-reminder-web/.vite/
-chiclete-reminder-web/.env
+chiclete-web/node_modules/
+chiclete-web/dist/
+chiclete-web/.vite/
+chiclete-web/.env
 
 ### Android / Gradle — artefatos locais ###
-chiclete-reminder-android/.gradle/
-chiclete-reminder-android/**/build/
-chiclete-reminder-android/local.properties
-chiclete-reminder-android/captures/
-chiclete-reminder-android/*.iml
-chiclete-reminder-android/.idea/
+chiclete-android/.gradle/
+chiclete-android/**/build/
+chiclete-android/local.properties
+chiclete-android/captures/
+chiclete-android/*.iml
+chiclete-android/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ build/
 ### Local tooling (never commit) ###
 .jdk/
 
+### Design exports (Canva, etc.) ###
+/Untitled design*.png
+
 ### Web client (Vite/npm) — artefatos locais ###
 chiclete-web/node_modules/
 chiclete-web/dist/


### PR DESCRIPTION
## Summary
- Ignora artefatos locais de clientes web/Android e arquivos de design

## Test plan
- [ ] `git status` limpo após build local do projeto


Made with [Cursor](https://cursor.com)